### PR TITLE
Use HTTPS to download NGINX

### DIFF
--- a/nginx-relay/Dockerfile
+++ b/nginx-relay/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get -y upgrade && \
 
 WORKDIR /opt
 
-RUN wget http://nginx.org/download/nginx-1.18.0.tar.gz && \
+RUN wget https://nginx.org/download/nginx-1.18.0.tar.gz && \
     tar -zxvf nginx-1.*.tar.gz && \
     cd nginx-1.* && \
     ./configure --prefix=/opt/nginx --user=nginx --group=nginx --with-http_ssl_module --with-ipv6 --with-threads --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module && \

--- a/nginx-terminate/Dockerfile
+++ b/nginx-terminate/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get -y upgrade && \
 
 WORKDIR /opt
 
-RUN wget http://nginx.org/download/nginx-1.18.0.tar.gz && \
+RUN wget https://nginx.org/download/nginx-1.18.0.tar.gz && \
     tar -zxvf nginx-1.*.tar.gz && \
     cd nginx-1.* && \
     ./configure --prefix=/opt/nginx --user=nginx --group=nginx --with-http_ssl_module --with-ipv6 --with-threads --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module && \


### PR DESCRIPTION
I don't know if using `http` was on purpose, but as NGINX provides a `https` endpoint why not using it?