### PR TITLE
docker.io is the correct package (at least in Ubuntu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 To run a Signal TLS proxy, you will need a host with a domain name that has ports 80 and 443 available.
 
-1. Install docker and docker-compose (`apt update && apt install docker docker-compose`)
+1. Install docker and docker-compose (`apt update && apt install docker.io docker-compose`)
 1. Clone this repository
 1. `./init-certificate.sh`
 1. `docker-compose up --detach`


### PR DESCRIPTION
it is really weird that docker-compose does not give a more meaningful error message when it cannot find the docker daemon