### PR TITLE
Automation friendly init script

### DIFF
--- a/init-certificate.sh
+++ b/init-certificate.sh
@@ -6,11 +6,19 @@ if ! [ -x "$(command -v docker-compose)" ]; then
 fi
 
 data_path="./data/certbot"
+domains="$SP_CERTBOT_DOMAIN"
 
-read -p "Enter domain name (eg. www.example.com): " domains
+# Only ask for domain if it's not set by environment
+if [ -z "$domains" ]; then
+  read -p "Enter domain name (eg. www.example.com): " domains
+fi
 
+decision="$SP_REPLACE_EXISTING"
 if [ -d "$data_path" ]; then
-  read -p "Existing data found. Continue and replace existing certificate? (y/N) " decision
+  if [ -z "$decision" ]; then
+    read -p "Existing data found. Continue and replace existing certificate? (y/N) " decision
+  fi
+
   if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
     exit
   fi

--- a/init-certificate.sh
+++ b/init-certificate.sh
@@ -14,7 +14,7 @@ if [ -z "$domains" ]; then
 fi
 
 decision="$SP_REPLACE_EXISTING"
-if [ -d "$data_path" ]; then
+if [ -L "$data_path/conf/active" ]; then
   if [ -z "$decision" ]; then
     read -p "Existing data found. Continue and replace existing certificate? (y/N) " decision
   fi


### PR DESCRIPTION
I made some changes to make the init script more automation friendly. I've created [Ansible playbooks](https://gitlab.com/stemid-ansible/playbooks/signal-proxy) to automate the setup of these signal proxies and these minor changes made that much easier.

It's a short term solution, I think the whole thing needs to be refactored to be more modern. But it's good enough for now.