### PR TITLE
Add missing block for upstream uptime.signal.org

### DIFF
--- a/data/nginx-relay/nginx.conf
+++ b/data/nginx-relay/nginx.conf
@@ -47,6 +47,10 @@ stream {
         server contentproxy.signal.org:443;
     }
 
+    upstream uptime {
+        server uptime.signal.org:443;
+    }
+
     upstream backup {
 	server api.backup.signal.org:443;
     }


### PR DESCRIPTION
This PR adds a missing upstream for the mapping declared at https://github.com/signalapp/Signal-TLS-Proxy/blob/master/data/nginx-relay/nginx.conf#L18.
The current configuration declares a mapping for `uptime.signal.org`, but doesn't associate any upstream.