### PR TITLE
Map Hash Bucket Size Fix

### DIFF
--- a/data/nginx-relay/nginx.conf
+++ b/data/nginx-relay/nginx.conf
@@ -8,6 +8,8 @@ events {
 }
 
 stream {
+    map_hash_max_size 2048;
+    map_hash_bucket_size 128;
     map $ssl_preread_server_name $name {
         textsecure-service.whispersystems.org	signal-service;
 	storage.signal.org			storage-service;


### PR DESCRIPTION
On default installation of the Proxy, the relay container running under Ubuntu 20.4 threw an error about not being able to build the hash map:
`nginx: [emerg] could not build map_hash, you should increase map_hash_bucket_size: 32`
The container was not able to start and looped into auto-restart.
A quick look into the map module references[1](http://nginx.org/en/docs/http/ngx_http_map_module.html) [2](http://nginx.org/en/docs/hash.html) showed that the sizes are not set by default anymore. 
This change in the nginx conf should fix the issue.