### PR TITLE
Update the signal-service URL

### DIFF
--- a/data/nginx-relay/nginx.conf
+++ b/data/nginx-relay/nginx.conf
@@ -10,6 +10,7 @@ events {
 stream {
     map $ssl_preread_server_name $name {
         textsecure-service.whispersystems.org	signal-service;
+	chat.signal.org				signal-service;
 	storage.signal.org			storage-service;
 	cdn.signal.org				signal-cdn;
 	cdn2.signal.org				signal-cdn2;
@@ -24,7 +25,7 @@ stream {
     }
 
     upstream signal-service {
-         server textsecure-service.whispersystems.org:443;
+         server chat.signal.org:443;
     }
 
     upstream storage-service {


### PR DESCRIPTION
New client versions won't connect properly anymore, since the proxy rejects connections to the new URL.