### PR TITLE
Make certbot reachable on port 80

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,6 @@ services:
     volumes:
       - ./data/certbot/conf:/etc/letsencrypt
       - ./data/certbot/www:/var/www/certbot
+    ports:
+      - "80:80"
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"


### PR DESCRIPTION
Certificates cannot be renewed unless certbot is reachable by Letsencrypt on port 80.