### PR TITLE
Add entries for cdsi.signal.org

### DIFF
--- a/data/nginx-relay/nginx.conf
+++ b/data/nginx-relay/nginx.conf
@@ -15,6 +15,7 @@ stream {
         cdn.signal.org                          signal-cdn;
         cdn2.signal.org                         signal-cdn2;
         api.directory.signal.org                directory;
+        cdsi.signal.org                         cdsi;
         contentproxy.signal.org                 content-proxy;
         uptime.signal.org                       uptime;
         api.backup.signal.org                   backup;
@@ -42,6 +43,10 @@ stream {
 
     upstream directory {
         server api.directory.signal.org:443;
+    }
+
+    upstream cdsi {
+        server cdsi.signal.org:443;
     }
 
     upstream content-proxy {


### PR DESCRIPTION
This adds rules entries for cdsi.signal.org (see https://github.com/signalapp/ContactDiscoveryService-Icelake) to the proxy config.