### PR TITLE
Expose Certbot ports

### DIFF
--- a/data/nginx-terminate/nginx.conf
+++ b/data/nginx-terminate/nginx.conf
@@ -10,7 +10,7 @@ http {
         listen 80;
 
         location /.well-known/acme-challenge/ {
-            root /var/www/certbot;
+            alias /var/www/certbot/;
         }
     }
 }

--- a/data/nginx-terminate/nginx.conf
+++ b/data/nginx-terminate/nginx.conf
@@ -12,6 +12,10 @@ http {
         location /.well-known/acme-challenge/ {
             alias /var/www/certbot/;
         }
+
+        location / {
+            return 404;
+        }
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - ./data/certbot/www:/var/www/certbot
     ports:
       - "443:443"
+      - "80:80"
     command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; /opt/nginx/sbin/nginx -s reload; done & /opt/nginx/sbin/nginx -c /etc/nginx/conf.d/nginx.conf -g \"daemon off;\"'"
   nginx-relay:
     build: ./nginx-relay/


### PR DESCRIPTION
We need to expose port 80 to allow [Certbot](https://certbot.eff.org/) to update certificates. See also: https://eff-certbot.readthedocs.io/en/stable/install.html#running-with-docker