### PR TITLE
[DRAFT] Use architecture-specific certbot image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ./data/nginx-relay:/etc/nginx/conf.d
     command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; /opt/nginx/sbin/nginx -s reload; done & /opt/nginx/sbin/nginx -c /etc/nginx/conf.d/nginx.conf -g \"daemon off;\"'"
   certbot:
-    image: certbot/certbot
+    image: certbot/certbot:arm64v8-latest
     restart: unless-stopped
     volumes:
       - ./data/certbot/conf:/etc/letsencrypt


### PR DESCRIPTION
I used the hack in this pull request to get the Proxy to work on a Raspberry Pi 4. Ideally we should check the system architecture and use the correct arch-specific certbot.

What is the sensible way to achieve this? I would like to update this PR with that.