### PR TITLE
Add SNI filtering

### DIFF
--- a/data/nginx-terminate/nginx.conf
+++ b/data/nginx-terminate/nginx.conf
@@ -20,15 +20,23 @@ http {
 }
 
 stream {
-
+    map $ssl_preread_server_name $proxy {
+        skyhook.loseyourip.com real;
+        default deny;
+    }
     upstream relay {
          server nginx-relay:4433;
     }
-
+    upstream real {
+        server 127.0.0.1:8443;
+    }
+    upstream deny {
+        server 127.0.0.1:9443;
+    }
+    
     server {
-        listen                443 ssl;
+        listen                8443 ssl;
         proxy_pass            relay;
-
         access_log            off;
         error_log             /dev/null;
 
@@ -36,6 +44,13 @@ stream {
         ssl_certificate_key /etc/letsencrypt/active/privkey.pem;
         include /etc/letsencrypt/options-ssl-nginx.conf;
         ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+     }
+    server {
+        listen                443 ;
+        proxy_pass            $proxy;
+        access_log            off;
+        error_log             /dev/null;
+	ssl_preread	on;
      }
 
 }

--- a/data/nginx-terminate/nginx.conf
+++ b/data/nginx-terminate/nginx.conf
@@ -21,7 +21,7 @@ http {
 
 stream {
     map $ssl_preread_server_name $proxy {
-        skyhook.loseyourip.com real;
+        DOMAIN_NAME_HERE real;
         default deny;
     }
     upstream relay {

--- a/init-certificate.sh
+++ b/init-certificate.sh
@@ -6,6 +6,7 @@ if ! [ -x "$(command -v docker-compose)" ]; then
 fi
 
 data_path="./data/certbot"
+conf_path="./data/nginx-terminate"
 
 read -p "Enter domain name (eg. www.example.com): " domains
 
@@ -16,6 +17,7 @@ if [ -d "$data_path" ]; then
   fi
 fi
 
+sed -i -r "s/DOMAIN_NAME_HERE/$domains/" $conf_path/nginx.conf
 
 if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
   echo "### Downloading recommended TLS parameters ..."

--- a/nginx-terminate/Dockerfile
+++ b/nginx-terminate/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update && apt-get -y upgrade && \
 
 WORKDIR /opt
 
-RUN wget https://nginx.org/download/nginx-1.18.0.tar.gz && \
+RUN wget https://nginx.org/download/nginx-1.19.4.tar.gz && \
     tar -zxvf nginx-1.*.tar.gz && \
     cd nginx-1.* && \
-    ./configure --prefix=/opt/nginx --user=nginx --group=nginx --with-http_ssl_module --with-ipv6 --with-threads --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module && \
+    ./configure --prefix=/opt/nginx --user=nginx --group=nginx --with-stream_ssl_preread_module --with-http_ssl_module --with-ipv6 --with-threads --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module && \
     make && make install && \
     cd .. && rm -rf nginx-1.*
 


### PR DESCRIPTION
These changes will allow for filtering off traffic if SNI does not match specified domain. This will allow for improved anonymity of Signal-TLS-Proxy by preventing IP scanners from discovering cert/tls information. 