### PR TITLE
Remove unused map entry for uptime in nginx config

### DIFF
--- a/data/nginx-relay/nginx.conf
+++ b/data/nginx-relay/nginx.conf
@@ -17,7 +17,6 @@ stream {
         api.directory.signal.org                directory;
         cdsi.signal.org                         cdsi;
         contentproxy.signal.org                 content-proxy;
-        uptime.signal.org                       uptime;
         api.backup.signal.org                   backup;
         sfu.voip.signal.org                     sfu;
         updates.signal.org                      updates;


### PR DESCRIPTION
Firstly, there is no upstream defined for "uptime".
Secondly, uptime.signal.org seems to resolve to localhost:
```
$ nslookup uptime.signal.org 1.1.1.1
Server:		1.1.1.1
Address:	1.1.1.1#53

Non-authoritative answer:
Name:	uptime.signal.org
Address: 127.0.0.1
```
Thus it seems, it's not being used anymore and this line might be a remnant and so it may be deleted.