### PR TITLE
Update README.md so signal.tube link works on IOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To run a Signal TLS proxy, you will need a host that has ports 80 and 443 availa
 1. `./init-certificate.sh`
 1. `docker-compose up --detach`
 
-Your proxy is now running! You can share this with the URL `https://signal.tube/#<your_host_name>`
+Your proxy is now running! You can share this with the URL `https://signal.tube#<your_host_name>`
 
 ## Updating from a previous version
 


### PR DESCRIPTION
Should read.
https://signal.tube#<your_host_name>
not
https://signal.tube/#<your_host_name>

the "/" breaks the link on IOS