### PR TITLE
Remove the legacy Secure Value Recovery service from the list of supported domains

### DIFF
--- a/data/nginx-relay/nginx.conf
+++ b/data/nginx-relay/nginx.conf
@@ -16,7 +16,6 @@ stream {
         cdsi.signal.org                         cdsi;
         contentproxy.signal.org                 content-proxy;
         uptime.signal.org                       uptime;
-        api.backup.signal.org                   backup;
         sfu.voip.signal.org                     sfu;
         svr2.signal.org                         svr2;
         updates.signal.org                      updates;
@@ -46,10 +45,6 @@ stream {
 
     upstream content-proxy {
         server contentproxy.signal.org:443;
-    }
-
-    upstream backup {
-        server api.backup.signal.org:443;
     }
 
     upstream sfu {


### PR DESCRIPTION
We will soon retire the legacy Secure Value Recovery service, and supporting `api.backup.signal.org` will be neither required nor helpful.