### PR TITLE
use dependabot to update dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/nginx-relay"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/nginx-terminate"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This will check for new versions of the images used in this project's dockerfiles, and if available, it will create a PR to update them.