### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 To run a Signal TLS proxy, you will need a host that has ports 80 and 443 available and a domain name that points to that host.
 
-1. Install docker and docker-compose (`apt update && apt install docker docker-compose`)
-1. Ensure your current user has access to docker (`adduser $USER docker`)
-1. Clone this repository
-1. `./init-certificate.sh`
-1. `docker-compose up --detach`
+1. Install Docker by following the instructions at https://docs.docker.com/engine/install/
+2. Clone this repository
+3. `./init-certificate.sh`
+4. `docker compose up --detach`
 
 Your proxy is now running! You can share this with the URL `https://signal.tube/#<your_host_name>`
 
@@ -16,7 +15,7 @@ If you've previously run a proxy, please update to the most recent version by pu
 
 ```shell
 git pull
-docker-compose down
-docker-compose build
-docker-compose up --detach
+docker compose down
+docker compose build
+docker compose up --detach
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   nginx-terminate:
     build: ./docker-nginx


### PR DESCRIPTION
This updates the README to use more up-to-date installation instructions. I also decided to sneak in a fix for a warning about a deprecated `version` line in `docker-compose.yml` while I was in here.