### PR TITLE
Pin nginx:alpine-stable version with a SHA

### DIFF
--- a/docker-nginx/Dockerfile
+++ b/docker-nginx/Dockerfile
@@ -1,4 +1,4 @@
 # This wraps the upstream nginx image so dependabot can watch it for changes.
 # If https://github.com/dependabot/dependabot-core/issues/390 is addressed, we
 # can just inline this into docker-compose.yml
-FROM nginx:1.26.1-alpine
+FROM nginx:stable-alpine@sha256:33001975a6ea5a2b78d108b64bdc89b434e31f523d3bc641ca2a3136d9024df8


### PR DESCRIPTION
Pin with a tag and a SHA so dependabot checks for the latest stable nginx instead of the latest major version (mainline)