### PR TITLE
Fix nginx map_hash building issues on Raspberry Pi

### DIFF
--- a/data/nginx-relay/nginx.conf
+++ b/data/nginx-relay/nginx.conf
@@ -7,6 +7,7 @@ events {
 }
 
 stream {
+    map_hash_bucket_size 128;
     map $ssl_preread_server_name $name {
         chat.signal.org                         signal-service;
         ud-chat.signal.org                      signal-service;


### PR DESCRIPTION
When running this docker container on a raspberry pi, the proxy fails. This is due to the signal relay failing because nginx can't create a map_hash.

See error:
```
sudo docker logs f9e47397ba89
2024/08/25 16:42:23 [emerg] 1#1: could not build map_hash, you should increase map_hash_bucket_size: 32
nginx: [emerg] could not build map_hash, you should increase map_hash_bucket_size: 32
2024/08/25 16:42:26 [emerg] 1#1: could not build map_hash, you should increase map_hash_bucket_size: 32
nginx: [emerg] could not build map_hash, you should increase map_hash_bucket_size: 32
``` 

adding map_hash_bucket_size to the nginx config fixes this issue when running on a raspberry pi.

Please test this change on other systems to make sure it doesn't break them