### PR TITLE
Remove svr3 upstream

### DIFF
--- a/data/nginx-relay/nginx-staging.conf
+++ b/data/nginx-relay/nginx-staging.conf
@@ -20,9 +20,6 @@ stream {
         svr2.staging.signal.org                 svr2;
         updates.signal.org                      updates;
         updates2.signal.org                     updates2;
-        backend1.svr3.staging.signal.org        svr31;
-        backend2.svr3.staging.signal.org        svr32;
-        backend3.svr3.staging.signal.org        svr33;
         default                                 deny;
     }
 
@@ -60,18 +57,6 @@ stream {
 
     upstream svr2 {
         server svr2.staging.signal.org:443;
-    }
-
-    upstream svr31 {
-        server backend1.svr3.staging.signal.org:443;
-    }
-
-    upstream svr32 {
-        server backend2.svr3.staging.signal.org:443;
-    }
-
-    upstream svr33 {
-        server backend3.svr3.staging.signal.org:443;
     }
 
     upstream updates {

--- a/data/nginx-relay/nginx.conf
+++ b/data/nginx-relay/nginx.conf
@@ -20,9 +20,6 @@ stream {
         svr2.signal.org                         svr2;
         updates.signal.org                      updates;
         updates2.signal.org                     updates2;
-        backend1.svr3.signal.org                svr31;
-        backend2.svr3.signal.org                svr32;
-        backend3.svr3.signal.org                svr33;
         default                                 deny;
     }
 
@@ -60,18 +57,6 @@ stream {
 
     upstream svr2 {
         server svr2.signal.org:443;
-    }
-
-    upstream svr31 {
-        server backend1.svr3.signal.org:443;
-    }
-
-    upstream svr32 {
-        server backend2.svr3.signal.org:443;
-    }
-
-    upstream svr33 {
-        server backend3.svr3.signal.org:443;
     }
 
     upstream updates {


### PR DESCRIPTION
It looks like these endpoints were removed by https://github.com/signalapp/Signal-Server/commit/8280106493496f035a0a773d3f9bdb9e5c85e82c and attempting to start the proxy now yields:

> host not found in upstream "backend1.svr3.signal.org:443"

Fix this by removing the upstream in the `nginx.conf`.