### PR TITLE
Quick typo fix for a missing brace to allow nginx-relay to start up

### DIFF
--- a/data/nginx-relay/nginx.conf
+++ b/data/nginx-relay/nginx.conf
@@ -54,6 +54,7 @@ stream {
 
     upstream grpc-chat {
         server grpc.chat.signal.org:443;
+    }
 
     upstream sfu {
         server sfu.voip.signal.org:443;


### PR DESCRIPTION
Quick typo fix for a missing brace to allow nginx-relay to start up